### PR TITLE
Vendor - Azure: Add deprecated Secret Scanning pattern for Azure SQL connection strings

### DIFF
--- a/vendors/README.md
+++ b/vendors/README.md
@@ -2,6 +2,24 @@
 -->
 # Vendors
 
+## Azure SQL Connection String
+
+
+<details>
+<summary>Pattern Format</summary>
+<p>
+
+```regex
+(?i)[a-z][a-z0-9-]+\.database(?:\.secure)?\.(?:(?:windows|usgovcloudapi)\.net|chinacloudapi\.cn|cloudapi\.de)
+```
+
+**Comments / Notes:**
+- Deprecated from Secret Scanning for private repositories: https://github.blog/changelog/2021-10-18-secret-scanning-no-longer-supports-azure-sql-connection-strings-in-private-repos/
+- Current Version: v1.0
+</p>
+</details>
+
+
 ## Grafana API token
 
 

--- a/vendors/README.md
+++ b/vendors/README.md
@@ -12,7 +12,12 @@
 ```regex
 (?i)[a-z][a-z0-9-]+\.database(?:\.secure)?\.(?:(?:windows|usgovcloudapi)\.net|chinacloudapi\.cn|cloudapi\.de)
 ```
-
+  
+**Sample**
+ ```
+  const db = "abc123.database.secure.windows.net"
+ ```
+  
 **Comments / Notes:**
 - Deprecated from Secret Scanning for private repositories: https://github.blog/changelog/2021-10-18-secret-scanning-no-longer-supports-azure-sql-connection-strings-in-private-repos/
 - Current Version: v1.0

--- a/vendors/patterns.yml
+++ b/vendors/patterns.yml
@@ -6,7 +6,7 @@ patterns:
     regex:
       pattern: |
         (?i)[a-z][a-z0-9-]+\.database(?:\.secure)?\.(?:(?:windows|usgovcloudapi)\.net|chinacloudapi\.cn|cloudapi\.de)
-      comments:
+    comments:
       - "Removed from Secret Scanning for private repositories: https://github.blog/changelog/2021-10-18-secret-scanning-no-longer-supports-azure-sql-connection-strings-in-private-repos/"
 
   - name: Grafana API token

--- a/vendors/patterns.yml
+++ b/vendors/patterns.yml
@@ -1,6 +1,14 @@
 name: Vendors
 
 patterns:
+  - name: Azure SQL Connection String
+    type: azure_sql_connection_string
+    regex:
+      pattern: |
+        (?i)[a-z][a-z0-9-]+\.database(?:\.secure)?\.(?:(?:windows|usgovcloudapi)\.net|chinacloudapi\.cn|cloudapi\.de)
+      comments:
+      - "Removed from Secret Scanning for private repositories: https://github.blog/changelog/2021-10-18-secret-scanning-no-longer-supports-azure-sql-connection-strings-in-private-repos/"
+
   - name: Grafana API token
     type: grafana_api_token
     regex:


### PR DESCRIPTION
Azure SQL connection strings for private repositories was deprecated (see [blog from 2021-10-18](https://github.blog/changelog/2021-10-18-secret-scanning-no-longer-supports-azure-sql-connection-strings-in-private-repos/)).  The regex powering the detection was made public in the blog. 