### PR TITLE
Further Base64 context for JWT

### DIFF
--- a/jwt/patterns.yml
+++ b/jwt/patterns.yml
@@ -7,11 +7,11 @@ patterns:
     description: "JSON Web Tokens are an open, industry standard RFC 7519 method for representing claims securely between two parties."
     regex:
       pattern: |
-        ey[I-L][A-Za-z0-9_-]{11,}(?:fQ|[3HXn]0|[Ntp95lRdx1FBZhVJ]9)={0,2}\.ey[I-L][A-Za-z0-9_-]{11,}(?:fQ|[3HXn]0|[Ntp95lRdx1FBZhVJ]9)={0,2}\.?[A-Za-z0-9_-]*={0,2}
+        ey[I-L][A-Za-z0-9_-]{10,}(?:fQ|[3HXn]0|[Ntp95lRdx1FBZhVJ]9)={0,2}\.ey[I-L][A-Za-z0-9_-]{10,}(?:fQ|[3HXn]0|[Ntp95lRdx1FBZhVJ]9)={0,2}\.?[A-Za-z0-9_-]*={0,2}
       start: |
         [^0-9A-Za-z_.-]|\A
       end: |
-        [^0-9A-Za-z_.-]|\z
+        [^0-9A-Za-z_.=-]|\z
 
     expected:
       - name: owasp-juice-shop.ts

--- a/jwt/patterns.yml
+++ b/jwt/patterns.yml
@@ -7,7 +7,7 @@ patterns:
     description: "JSON Web Tokens are an open, industry standard RFC 7519 method for representing claims securely between two parties."
     regex:
       pattern: |
-        ey[A-Za-z0-9-_]{12,}[Q90]={0,2}\.ey[A-Za-z0-9-_]{12,}[Q90]={0,2}\.?[A-Za-z0-9-_=]*
+        ey[I-L][A-Za-z0-9_-]{11,}(?:fQ|[3HXn]0|[Ntp95lRdx1FBZhVJ]9)={0,2}\.ey[I-L][A-Za-z0-9_-]{11,}(?:fQ|[3HXn]0|[Ntp95lRdx1FBZhVJ]9)={0,2}\.?[A-Za-z0-9_-]*={0,2}
       start: |
         [^0-9A-Za-z_.-]|\A
       end: |

--- a/testing/test_jwt.py
+++ b/testing/test_jwt.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+from base64 import urlsafe_b64encode as b64encode
+import re
+
+for c in range(0, 255):
+    for d in range(0, 255):
+        for l in range(0, 2):
+            token = (
+                b64encode(('{"' + chr(c) + chr(d) + ('.' * (l + 2)) + chr(c) + chr(d) + '}').encode('utf-8')).decode('utf-8') + '.' +
+                b64encode(('{"' + chr(c) + chr(d) + ('.' * (l + 2)) + chr(c) + chr(d) + '}').encode('utf-8')).decode('utf-8') + '.' +
+                b64encode(('{"' + chr(c) + chr(d) + ('.' * (l + 2)) + chr(c) + chr(d) + '}').encode('utf-8')).decode('utf-8')
+            )
+
+            print(token)
+            if '=' in token:
+                print(re.sub('=', '', token))
+


### PR DESCRIPTION
Even better JWT regex.

Tested using generated Base64, of the form:

```python
#!/usr/bin/env python3

from base64 import urlsafe_b64encode as b64encode
import re

for c in range(0, 255):
    for d in range(0, 255):
        for l in range(0, 2):
            token = (
                b64encode(('{"' + chr(c) + chr(d) + ('.' * (l + 2)) + chr(c) + chr(d) + '}').encode('utf-8')).decode('utf-8') + '.' +
                b64encode(('{"' + chr(c) + chr(d) + ('.' * (l + 2)) + chr(c) + chr(d) + '}').encode('utf-8')).decode('utf-8') + '.' +
                b64encode(('{"' + chr(c) + chr(d) + ('.' * (l + 2)) + chr(c) + chr(d) + '}').encode('utf-8')).decode('utf-8')
            )

            print(token)
            if '=' in token:
                print(re.sub('=', '', token))
```