### PR TITLE
Add README.md as ignored paths

### DIFF
--- a/.github/secret_scanning.yml
+++ b/.github/secret_scanning.yml
@@ -2,3 +2,5 @@ paths-ignore:
   - ".venv/*"
   - "*/__snapshots__/*"
   - "*/patterns.yml"
+  - "README.md"
+  - "*/README.md"


### PR DESCRIPTION
We don't want self-referential hits on the `README.md`, which are generated from the `patterns.yml` files