### PR TITLE
Password store Arc, metadata files

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This repository extends the [list of supported Vendors out of the box](https://d
 - JWT
 
 
-### [Password Stores](./password_stores)
+### [Password Stores](./password_store)
 
 - Arc
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ This repository extends the [list of supported Vendors out of the box](https://d
 - JWT
 
 
+### [Password Stores](./password_stores)
+
+- Arc
+
+
 ### [Personally identifiable information (PII)](./pii)
 
 - IBAN

--- a/password_store/README.md
+++ b/password_store/README.md
@@ -1,0 +1,46 @@
+<!-- WARNING: This README is generated automatically
+-->
+# Password stores
+
+## Arc
+
+Arc password stores are created by the Arc open source software (https://github.com/evilsocket/arc). They are AES encrypted, but should not be stored in shared repositories.
+
+<details>
+<summary>Pattern Format</summary>
+<p>
+
+```regex
+{"id":[0-9]+,"title":"[^"]+","encryption":"[^"]+","created_at":"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}(Z|[+-][0-9]{2}:[0-9]{2})","updated_at":"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}(Z|[+-][0-9]{2}:[0-9]{2})","expired_at":"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]{6})?(Z|[+-][0-9]{2}:[0-9]{2})","prune":(true|false),"notified":(true|false),"compressed":(true|false),"pinned":(true|false),"size":[0-9]+,"next_id":[0-9]+}
+```
+
+**Comments / Notes:**
+
+- Current Version: v0.1
+- This spots `meta.json` files created by Arc, not the secrets themselves
+- The encrypted secrets will be in a numbered directory below the detected `meta.json` file
+- This can also spot uncompressed tar file backups created by Arc
+</p>
+</details>
+
+
+<details>
+<summary>Start Pattern</summary>
+<p>
+
+```regex
+\A|\x00
+```
+
+</p>
+</details>
+<details>
+<summary>End Pattern</summary>
+<p>
+
+```regex
+\Z|\x00
+```
+
+</p>
+</details>

--- a/password_store/meta.json
+++ b/password_store/meta.json
@@ -1,0 +1,1 @@
+{"id":2,"title":"Foo","encryption":"aes","created_at":"2023-04-28T14:33:09.863337+01:00","updated_at":"2023-04-28T14:33:09.863337+01:00","expired_at":"0001-01-01T00:00:00Z","prune":false,"notified":false,"compressed":false,"pinned":false,"size":199,"next_id":1}

--- a/password_store/patterns.yml
+++ b/password_store/patterns.yml
@@ -1,0 +1,25 @@
+
+name: Password stores
+
+patterns:
+  - name: Arc
+    type: arc
+    description: "Arc password stores are created by the Arc open source software (https://github.com/evilsocket/arc). They are AES encrypted, but should not be stored in shared repositories."
+    regex:
+      pattern: |
+        {"id":[0-9]+,"title":"[^"]+","encryption":"[^"]+","created_at":"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}(Z|[+-][0-9]{2}:[0-9]{2})","updated_at":"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}(Z|[+-][0-9]{2}:[0-9]{2})","expired_at":"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]{6})?(Z|[+-][0-9]{2}:[0-9]{2})","prune":(true|false),"notified":(true|false),"compressed":(true|false),"pinned":(true|false),"size":[0-9]+,"next_id":[0-9]+}
+      start: |
+        \A|\x00
+      end: |
+        \Z|\x00
+
+    expected:
+      - name: meta.json
+        start_offset: 0
+        end_offset: 261
+
+    comments:
+      - This spots `meta.json` files created by Arc, not the secrets themselves
+      - The encrypted secrets will be in a numbered directory below the detected `meta.json` file
+      - This can also spot uncompressed tar file backups created by Arc
+ 


### PR DESCRIPTION
Added detection for metadata files from the [Arc password manager](https://github.com/evilsocket/arc/)

Works on an expected file. Created README.md

For some reason I had to manually edit the top-level README.md to include the link to the new folder, not sure why - I ran the script
