### PR TITLE
Accounted for headers in GPG private key

### DIFF
--- a/rsa/README.md
+++ b/rsa/README.md
@@ -50,7 +50,7 @@
 <p>
 
 ```regex
---BEGIN PGP PRIVATE KEY BLOCK--+[a-zA-Z0-9+/=\s]+--+END PGP PRIVATE KEY BLOCK--
+--BEGIN PGP PRIVATE KEY BLOCK--+(?:[\r\n]+((Version|Comment|MessageID|Hash|Charset): [^\r\n]+[\r\n]+)+[\r\n]+)?[a-zA-Z0-9+/=\s]+--+END PGP PRIVATE KEY BLOCK--
 ```
 
 **Comments / Notes:**

--- a/rsa/patterns.yml
+++ b/rsa/patterns.yml
@@ -36,11 +36,14 @@ patterns:
     type: gpg_private_key
     regex:
       pattern: |
-        --BEGIN PGP PRIVATE KEY BLOCK--+[a-zA-Z0-9+/=\s]+--+END PGP PRIVATE KEY BLOCK--
+        --BEGIN PGP PRIVATE KEY BLOCK--+(?:[\r\n]+((Version|Comment|MessageID|Hash|Charset): [^\r\n]+[\r\n]+)+[\r\n]+)?[a-zA-Z0-9+/=\s]+--+END PGP PRIVATE KEY BLOCK--
     expected:
       - name: GeekMasher GPG.asc
         start_offset: 3
         end_offset: 6651
+      - name: GeekMasher_GPG_with_headers.asc
+        start_offset: 3
+        end_offset: 6728
 
 
   - name: SSH Public Key


### PR DESCRIPTION
Added extra testcase and fixed pattern to allow headers in GPG private key blocks

Fixes https://github.com/advanced-security/secret-scanning-custom-patterns/issues/46

* Updated README
* changed rsa/patterns.yml
* added a testcase
* tested locally with test script