### PR TITLE
Fix Arc pattern

### DIFF
--- a/password_store/patterns.yml
+++ b/password_store/patterns.yml
@@ -11,7 +11,7 @@ patterns:
       start: |
         \A|\x00
       end: |
-        \z|\x00
+        \n?\z|\x00
 
     expected:
       - name: meta.json

--- a/password_store/patterns.yml
+++ b/password_store/patterns.yml
@@ -11,7 +11,7 @@ patterns:
       start: |
         \A|\x00
       end: |
-        \Z|\x00
+        \z|\x00
 
     expected:
       - name: meta.json


### PR DESCRIPTION
Changed `\Z` to `\z`.

The former appears to work in hyperscan in Python, but not in GitHub Secret Scanning.