### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Codeowners
 
-* @geekmasher @aegilops
+* @advanced-security/oss-maintainers @aegilops


### PR DESCRIPTION
This pull request makes a small update to the `.github/CODEOWNERS` file, assigning ownership to the `@advanced-security/oss-maintainers` team instead of the previous user.