### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-markdown.yml
+++ b/.github/workflows/pr-markdown.yml
@@ -1,6 +1,7 @@
 name: Markdown Validation
 permissions:
   contents: read
+  pull-requests: write
 
 on:
   pull_request:
@@ -27,8 +28,6 @@ jobs:
           token: ${{ steps.get_workflow_token.outputs.token }}
 
       - name: Check git status
-        env:
-          GH_TOKEN: ${{ steps.get_workflow_token.outputs.token }}
         run: |
           if [ -z "$(git status --porcelain)" ]; then
             gh pr comment --edit-last ${{ github.event.number }} \

--- a/.github/workflows/pr-markdown.yml
+++ b/.github/workflows/pr-markdown.yml
@@ -1,4 +1,6 @@
 name: Markdown Validation
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/advanced-security/secret-scanning-custom-patterns/security/code-scanning/3](https://github.com/advanced-security/secret-scanning-custom-patterns/security/code-scanning/3)

To fix the problem, an explicit `permissions` block should be added at the workflow or job level to limit the privileges granted to the default `GITHUB_TOKEN`. The minimal recommended setting is `contents: read`, which allows the workflow steps to read repository contents but not modify them. Since the workflow uses a GitHub App token to perform actions like PR comments, additional permissions (like `pull-requests: write`) for the default `GITHUB_TOKEN` may not be needed unless the workflow fails with permission errors. The edit should be made at the root of the workflow YAML file (right after `name: Markdown Validation`) or under the individual job if some jobs require different permissions. This involves adding:

```yaml
permissions:
  contents: read
```

If you discover later that the workflow requires additional permissions for the default token, you can incrementally allow them. For now, just add this block beneath the `name` line.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
