### PR TITLE
Add Insecure Configuration custom patterns (cleartext LDAP/HTTP, trustServerCertificate)

### DIFF
--- a/.github/workflows/pr-markdown.yml
+++ b/.github/workflows/pr-markdown.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Check git status
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.get_workflow_token.outputs.token }}
         run: |
           if [ -z "$(git status --porcelain)" ]; then
             gh pr comment --edit-last ${{ github.event.number }} \

--- a/.github/workflows/pr-markdown.yml
+++ b/.github/workflows/pr-markdown.yml
@@ -28,6 +28,8 @@ jobs:
           token: ${{ steps.get_workflow_token.outputs.token }}
 
       - name: Check git status
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           if [ -z "$(git status --porcelain)" ]; then
             gh pr comment --edit-last ${{ github.event.number }} \

--- a/README.md
+++ b/README.md
@@ -70,6 +70,17 @@ Custom Secret Scanning Patterns repository.
 - OAuth client secret and ID pair
   
 
+### [Insecure Configuration](./insecure_configuration)
+
+
+
+- Cleartext LDAP URL
+
+- Insecure trustServerCertificate
+
+- Cleartext HTTP endpoint
+  
+
 ### [JWT](./jwt)
 
 

--- a/insecure_configuration/DbConnectivityCheck.java
+++ b/insecure_configuration/DbConnectivityCheck.java
@@ -1,0 +1,42 @@
+package com.example.db;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Ad-hoc connectivity probe against the SQL Server warehouse.
+ *
+ * Reachable from {@code GET /api/admin/db-check} so the insecure-connection
+ * sink below is not discarded as unreachable.
+ */
+@RestController
+@RequestMapping("/api/admin")
+public class DbConnectivityCheck {
+
+    /**
+     * VULNERABILITY — CWE-295 (Improper Certificate Validation):
+     * {@code trustServerCertificate=true} disables TLS certificate validation
+     * on the JDBC connection, so the driver accepts ANY server certificate.
+     * Combined with {@code encrypt=true} this gives a false sense of security:
+     * the channel is encrypted but unauthenticated, enabling a man-in-the-middle
+     * to impersonate the database. Mirrors the JDBC URLs in application-*.yaml.
+     */
+    private static final String JDBC_URL =
+            "jdbc:sqlserver://prod-db01.corp.acme.com:1433;databaseName=AcmePortal;"
+                    + "encrypt=true;trustServerCertificate=true;loginTimeout=5";
+
+    @GetMapping("/db-check")
+    public String check() {
+        try (Connection connection =
+                     DriverManager.getConnection(JDBC_URL, "acme_app_prod", "ProdDB#2024!")) {
+            return "connected: " + connection.getCatalog();
+        } catch (SQLException e) {
+            return "error: " + e.getMessage();
+        }
+    }
+}

--- a/insecure_configuration/README.md
+++ b/insecure_configuration/README.md
@@ -69,7 +69,7 @@ _version: v0.1_
 <summary>Pattern Format</summary>
 
 ```regex
-[tT]rust[sS]erver[cC]ertificate[ \t]*=[ \t]*[tT]rue
+(?i)trustServerCertificate[ \t]*=[ \t]*true
 ```
 
 </details>

--- a/insecure_configuration/README.md
+++ b/insecure_configuration/README.md
@@ -1,0 +1,154 @@
+<!-- WARNING: This README is generated automatically
+-->
+
+<!-- markdownlint-disable no-inline-html -->
+
+# Insecure Configuration
+
+## Cleartext LDAP URL
+
+
+
+Cleartext ldap:// URL. LDAP binds (including the bind DN and password) are
+transmitted unencrypted (CWE-319). Use ldaps:// or STARTTLS instead.
+
+_version: v0.1_
+
+**Comments / Notes:**
+
+
+- Only matches the insecure ldap:// scheme; ldaps:// is intentionally not matched
+
+- Pair with a CodeQL query to confirm the URL reaches an LDAP context/bind sink
+  
+
+<details>
+<summary>Pattern Format</summary>
+
+```regex
+ldap://[a-zA-Z0-9._:\-/]+
+```
+
+</details>
+
+<details>
+<summary>Start Pattern</summary>
+
+```regex
+\A|[^a-zA-Z0-9]
+```
+
+</details><details>
+<summary>End Pattern</summary>
+
+```regex
+\z|["'`\s,;]
+```
+
+</details>
+
+## Insecure trustServerCertificate
+
+
+
+trustServerCertificate=true disables TLS certificate validation on a JDBC
+connection (CWE-295), so the driver accepts any server certificate and the
+encrypted channel is unauthenticated (man-in-the-middle).
+
+_version: v0.1_
+
+**Comments / Notes:**
+
+
+- Matches only the insecure '=true' value; '=false' is not matched
+
+- Case-insensitive on the property name and value, allows spaces around '='
+
+- Pair with a CodeQL query to confirm the URL reaches a JDBC/DB connection sink
+  
+
+<details>
+<summary>Pattern Format</summary>
+
+```regex
+[tT]rust[sS]erver[cC]ertificate[ \t]*=[ \t]*[tT]rue
+```
+
+</details>
+
+<details>
+<summary>Start Pattern</summary>
+
+```regex
+\A|[^a-zA-Z]
+```
+
+</details><details>
+<summary>End Pattern</summary>
+
+```regex
+\z|[^a-zA-Z]
+```
+
+</details>
+
+## Cleartext HTTP endpoint
+
+
+
+A cleartext http:// endpoint configured against a URL/endpoint key
+(CWE-319). Traffic to the endpoint, including any credentials it carries,
+crosses the network unencrypted. Use https:// instead.
+
+_version: v0.1_
+
+**Comments / Notes:**
+
+
+- Anchored on a preceding URL/endpoint-style config key to cut false positives from unrelated http:// URLs (e.g. XML namespaces, schema locations)
+
+- Loopback/localhost endpoints (localhost, 127.0.0.0/8, 0.0.0.0, ::1) are not matched
+
+- Only matches http://; https:// is intentionally not matched
+
+- Pair with a CodeQL query to confirm the URL reaches a network request sink
+  
+
+<details>
+<summary>Pattern Format</summary>
+
+```regex
+http://[^\s"'`<>\\]+
+```
+
+</details>
+
+<details>
+<summary>Start Pattern</summary>
+
+```regex
+(?:\A|[^a-zA-Z0-9])(?i)(?:url|uri|endpoint|base[_-]?url|base[_-]?uri|href|callback|webhook|target|location)[ \t]*[:=][ \t]*['"]?
+```
+
+</details><details>
+<summary>End Pattern</summary>
+
+```regex
+\z|['"`\s<>]
+```
+
+</details>
+
+<details>
+<summary>Additional Matches</summary>
+
+Add these additional matches to the [Secret Scanning Custom Pattern](https://docs.github.com/en/enterprise-cloud@latest/code-security/secret-scanning/defining-custom-patterns-for-secret-scanning#example-of-a-custom-pattern-specified-using-additional-requirements).
+
+
+- Not Match:
+
+  ```regex
+  ^http://(?:localhost|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|0\.0\.0\.0|\[::1\]|::1)(?:[:/?#]|$)
+  ```
+
+</details>

--- a/insecure_configuration/README.md
+++ b/insecure_configuration/README.md
@@ -8,7 +8,6 @@
 ## Cleartext LDAP URL
 
 
-
 Cleartext ldap:// URL. LDAP binds (including the bind DN and password) are
 transmitted unencrypted (CWE-319). Use ldaps:// or STARTTLS instead.
 
@@ -50,10 +49,9 @@ ldap://[a-zA-Z0-9._:\-/]+
 ## Insecure trustServerCertificate
 
 
-
-trustServerCertificate=true disables TLS certificate validation on a JDBC
-connection (CWE-295), so the driver accepts any server certificate and the
-encrypted channel is unauthenticated (man-in-the-middle).
+Setting the JDBC trustServerCertificate property to true disables TLS
+certificate validation (CWE-295), so the driver accepts any server
+certificate and the encrypted channel is unauthenticated (man-in-the-middle).
 
 _version: v0.1_
 
@@ -93,7 +91,6 @@ _version: v0.1_
 </details>
 
 ## Cleartext HTTP endpoint
-
 
 
 A cleartext http:// endpoint configured against a URL/endpoint key

--- a/insecure_configuration/WebSecurityConfig.java
+++ b/insecure_configuration/WebSecurityConfig.java
@@ -1,0 +1,96 @@
+package com.example.security.config;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.ldap.core.support.LdapContextSource;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.ldap.authentication.BindAuthenticator;
+import org.springframework.security.ldap.authentication.LdapAuthenticationProvider;
+import org.springframework.security.ldap.search.FilterBasedLdapUserSearch;
+import org.springframework.security.ldap.userdetails.DefaultLdapAuthoritiesPopulator;
+import org.springframework.security.web.SecurityFilterChain;
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true)
+public class WebSecurityConfig {
+    // CWE-319: Cleartext LDAP — ldap:// transmits credentials over an unencrypted channel.
+    //          Should be ldaps:// or STARTTLS.
+    private static final String LDAP_URL = "ldap://ldap.corp.acme.com:389";
+    private static final String LDAP_BASE_DN  = "dc=corp,dc=acme,dc=com";
+    private static final String LDAP_USER_DN  = "cn=svc-acme-ldap,ou=ServiceAccounts,dc=corp,dc=acme,dc=com";
+    // CWE-798: Hardcoded service-account credential — a real AD password stored in source.
+    //          Should be injected via Vault / environment variable.
+    private static final String LDAP_PASSWORD = "Acm3$vc!Ldap#2024";
+    private static final String USER_SEARCH_BASE   = "ou=Users,dc=corp,dc=acme,dc=com";
+    private static final String USER_SEARCH_FILTER = "(sAMAccountName={0})";
+    private static final String GROUP_SEARCH_BASE  = "ou=Groups,dc=corp,dc=acme,dc=com";
+    @Bean
+    public LdapContextSource ldapContextSource() {
+        LdapContextSource ctx = new LdapContextSource();
+        // CWE-319: Same cleartext ldap:// URL used for the context source binding
+        ctx.setUrl(LDAP_URL);
+        ctx.setBase(LDAP_BASE_DN);
+        ctx.setUserDn(LDAP_USER_DN);
+        // CWE-798: Manager password hardcoded via .setPassword()
+        ctx.setPassword(LDAP_PASSWORD);
+        ctx.afterPropertiesSet();
+        return ctx;
+    }
+    @Bean
+    public LdapAuthenticationProvider ldapAuthenticationProvider() {
+        FilterBasedLdapUserSearch userSearch =
+                new FilterBasedLdapUserSearch(USER_SEARCH_BASE, USER_SEARCH_FILTER, ldapContextSource());
+        BindAuthenticator authenticator = new BindAuthenticator(ldapContextSource());
+        authenticator.setUserSearch(userSearch);
+        DefaultLdapAuthoritiesPopulator authoritiesPopulator =
+                new DefaultLdapAuthoritiesPopulator(ldapContextSource(), GROUP_SEARCH_BASE);
+        authoritiesPopulator.setGroupRoleAttribute("cn");
+        authoritiesPopulator.setGroupSearchFilter("(member={0})");
+        return new LdapAuthenticationProvider(authenticator, authoritiesPopulator);
+    }
+    @Bean
+    public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
+        AuthenticationManagerBuilder builder =
+                http.getSharedObject(AuthenticationManagerBuilder.class);
+        builder.authenticationProvider(ldapAuthenticationProvider());
+        return builder.build();
+    }
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            // CSRF/frame settings relaxed so the sample API (and H2 console) is
+            // callable for the IDOR demo. The vulnerability under test is the
+            // missing PER-RECORD authorization in StatementService, not the
+            // endpoint-level matchers below.
+            .csrf(csrf -> csrf.disable())
+            .headers(headers -> headers.frameOptions(frame -> frame.disable()))
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/actuator/health", "/actuator/info").permitAll()
+                .requestMatchers("/acme-portal/public/**").permitAll()
+                .requestMatchers("/api/**", "/h2-console/**", "/error").permitAll()
+                .requestMatchers("/acme-portal/admin/**").hasRole("ACME_ADMINS")
+                .anyRequest().authenticated()
+            )
+            .formLogin(form -> form
+                .loginPage("/login")
+                .defaultSuccessUrl("/acme-portal/dashboard", true)
+                .failureUrl("/login?error=true")
+                .permitAll()
+            )
+            .logout(logout -> logout
+                .logoutUrl("/logout")
+                .logoutSuccessUrl("/login?logout=true")
+                .invalidateHttpSession(true)
+                .clearAuthentication(true)
+                .permitAll()
+            )
+            .sessionManagement(session -> session
+                .maximumSessions(1)
+                .expiredUrl("/login?expired=true")
+            );
+        return http.build();
+    }
+}

--- a/insecure_configuration/application-prod.yaml
+++ b/insecure_configuration/application-prod.yaml
@@ -1,0 +1,95 @@
+spring:
+  application:
+    name: acme-portal
+  datasource:
+    # CWE-798: Hardcoded credential — low-entropy/generic password caught by Fortify, missed by GitHub tools
+    # CWE-295: trustServerCertificate=true disables TLS certificate validation
+    url: jdbc:sqlserver://prod-db01.corp.acme.com:1433;databaseName=AcmePortal;encrypt=true;trustServerCertificate=true;loginTimeout=30;applicationName=AcmePortal
+    username: acme_app_prod
+    password: ProdDB#2024!
+    driver-class-name: com.microsoft.sqlserver.jdbc.SQLServerDriver
+    hikari:
+      maximum-pool-size: 50
+      minimum-idle: 10
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
+      leak-detection-threshold: 60000
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.SQLServerDialect
+        jdbc:
+          batch_size: 50
+  cache:
+    type: redis
+  redis:
+    host: prod-redis-primary.corp.acme.com
+    port: 6379
+    password: ProdRedis@SecureP@ss1
+    ssl: true
+    timeout: 2000
+  mail:
+    host: smtp.corp.acme.com
+    port: 587
+    username: noreply@acme.com
+    password: ProdMail#Smtp04
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+logging:
+  level:
+    root: ERROR
+    com.acme: WARN
+  file:
+    name: /var/log/acme-portal/prod.log
+  pattern:
+    file: "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n"
+server:
+  port: 8443
+  ssl:
+    enabled: true
+    key-store: /etc/acme/prod-keystore.p12
+    key-store-password: ProdKeystore@2024
+    key-store-type: PKCS12
+    key-alias: acme-prod
+  servlet:
+    context-path: /acme-portal
+  tomcat:
+    max-threads: 200
+    accept-count: 100
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health
+  endpoint:
+    health:
+      show-details: never
+acme:
+  feature-flags:
+    enable-beta-dashboard: false
+    enable-audit-log: true
+  storage:
+    base-path: /data/acme-prod-uploads
+    max-file-size-mb: 100
+  # CWE-319: Report server configured over plaintext HTTP — no TLS in production
+  reporting:
+    server:
+      # Internal SSRS / report server endpoint — HTTP not HTTPS
+      url: http://reports.corp.acme.com:8080/ReportServer
+      username: svc-reports
+      password: Rpt$vc#Prod1
+      timeout-seconds: 60
+      retry-attempts: 3
+  audit:
+    retention-days: 365
+    export:
+      # CWE-319: Audit log export sink also over plaintext HTTP
+      endpoint: http://audit-collector.corp.acme.com:9200/acme-audit

--- a/insecure_configuration/negatives.conf
+++ b/insecure_configuration/negatives.conf
@@ -1,0 +1,20 @@
+# Negative controls — none of the lines below must match any pattern.
+
+# Secure LDAP over TLS must not be flagged as cleartext ldap://
+ldap_url_secure: ldaps://ldap.corp.acme.com:636
+
+# TLS certificate validation explicitly enabled must not match
+jdbc_secure: jdbc:sqlserver://db.corp.acme.com:1433;encrypt=true;trustServerCertificate=false;loginTimeout=30
+
+# HTTPS endpoints behind a config key must not match the cleartext-http pattern
+url: https://reports.corp.acme.com/ReportServer
+endpoint: https://audit-collector.corp.acme.com:9200/acme-audit
+
+# Cleartext HTTP to localhost / loopback is excluded by design
+health_url: http://localhost:8080/actuator/health
+metrics_endpoint: http://127.0.0.1:9200/_cluster/health
+bind_url: http://0.0.0.0:8080/
+
+# Bare http:// schema URLs without a config key (e.g. XML namespaces) must not match
+xmlns="http://www.w3.org/2001/XMLSchema-instance"
+schemaLocation = http://maven.apache.org/POM/4.0.0

--- a/insecure_configuration/patterns.yml
+++ b/insecure_configuration/patterns.yml
@@ -1,0 +1,97 @@
+name: Insecure Configuration
+
+patterns:
+  - name: Cleartext LDAP URL
+    type: cleartext_ldap_url
+    description: |
+      Cleartext ldap:// URL. LDAP binds (including the bind DN and password) are
+      transmitted unencrypted (CWE-319). Use ldaps:// or STARTTLS instead.
+    comments:
+      - "Only matches the insecure ldap:// scheme; ldaps:// is intentionally not matched"
+      - "Pair with a CodeQL query to confirm the URL reaches an LDAP context/bind sink"
+    regex:
+      version: 0.1
+      pattern: |
+        ldap://[a-zA-Z0-9._:\-/]+
+      start: |
+        \A|[^a-zA-Z0-9]
+      end: |
+        \z|["'`\s,;]
+    expected:
+      - name: WebSecurityConfig.java
+        start_offset: 1364
+        end_offset: 1393
+    test:
+      data: ldap://ldap.corp.acme.com:389
+      start_offset: 0
+      end_offset: 29
+
+  - name: Insecure trustServerCertificate
+    type: insecure_trust_server_certificate
+    description: |
+      trustServerCertificate=true disables TLS certificate validation on a JDBC
+      connection (CWE-295), so the driver accepts any server certificate and the
+      encrypted channel is unauthenticated (man-in-the-middle).
+    comments:
+      - "Matches only the insecure '=true' value; '=false' is not matched"
+      - "Case-insensitive on the property name and value, allows spaces around '='"
+      - "Pair with a CodeQL query to confirm the URL reaches a JDBC/DB connection sink"
+    regex:
+      version: 0.1
+      pattern: |
+        [tT]rust[sS]erver[cC]ertificate[ \t]*=[ \t]*[tT]rue
+      start: |
+        \A|[^a-zA-Z]
+      end: |
+        \z|[^a-zA-Z]
+    expected:
+      - name: DbConnectivityCheck.java
+        start_offset: 693
+        end_offset: 720
+      - name: DbConnectivityCheck.java
+        start_offset: 1258
+        end_offset: 1285
+      - name: application-prod.yaml
+        start_offset: 190
+        end_offset: 217
+      - name: application-prod.yaml
+        start_offset: 347
+        end_offset: 374
+    test:
+      data: trustServerCertificate=true
+      start_offset: 0
+      end_offset: 27
+
+  - name: Cleartext HTTP endpoint
+    type: cleartext_http_endpoint
+    description: |
+      A cleartext http:// endpoint configured against a URL/endpoint key
+      (CWE-319). Traffic to the endpoint, including any credentials it carries,
+      crosses the network unencrypted. Use https:// instead.
+    comments:
+      - "Anchored on a preceding URL/endpoint-style config key to cut false positives from unrelated http:// URLs (e.g. XML namespaces, schema locations)"
+      - "Loopback/localhost endpoints (localhost, 127.0.0.0/8, 0.0.0.0, ::1) are not matched"
+      - "Only matches http://; https:// is intentionally not matched"
+      - "Pair with a CodeQL query to confirm the URL reaches a network request sink"
+    regex:
+      version: 0.1
+      pattern: |
+        http://[^\s"'`<>\\]+
+      start: |
+        (?:\A|[^a-zA-Z0-9])(?i)(?:url|uri|endpoint|base[_-]?url|base[_-]?uri|href|callback|webhook|target|location)[ \t]*[:=][ \t]*['"]?
+      end: |
+        \z|['"`\s<>]
+      additional_not_match:
+        # loopback / localhost / unspecified address
+        - ^http://(?:localhost|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|0\.0\.0\.0|\[::1\]|::1)(?:[:/?#]|$)
+    expected:
+      - name: application-prod.yaml
+        start_offset: 2317
+        end_offset: 2363
+      - name: application-prod.yaml
+        start_offset: 2605
+        end_offset: 2657
+    test:
+      data: "url: http://reports.corp.acme.com:8080/ReportServer"
+      start_offset: 5
+      end_offset: 51

--- a/insecure_configuration/patterns.yml
+++ b/insecure_configuration/patterns.yml
@@ -6,6 +6,7 @@ patterns:
     description: |
       Cleartext ldap:// URL. LDAP binds (including the bind DN and password) are
       transmitted unencrypted (CWE-319). Use ldaps:// or STARTTLS instead.
+    experimental: true
     comments:
       - "Only matches the insecure ldap:// scheme; ldaps:// is intentionally not matched"
       - "Pair with a CodeQL query to confirm the URL reaches an LDAP context/bind sink"
@@ -32,6 +33,7 @@ patterns:
       Setting the JDBC trustServerCertificate property to true disables TLS
       certificate validation (CWE-295), so the driver accepts any server
       certificate and the encrypted channel is unauthenticated (man-in-the-middle).
+    experimental: true
     comments:
       - "Matches only the insecure '=true' value; '=false' is not matched"
       - "Case-insensitive on the property name and value, allows spaces around '='"
@@ -68,6 +70,7 @@ patterns:
       A cleartext http:// endpoint configured against a URL/endpoint key
       (CWE-319). Traffic to the endpoint, including any credentials it carries,
       crosses the network unencrypted. Use https:// instead.
+    experimental: true
     comments:
       - "Anchored on a preceding URL/endpoint-style config key to cut false positives from unrelated http:// URLs (e.g. XML namespaces, schema locations)"
       - "Loopback/localhost endpoints (localhost, 127.0.0.0/8, 0.0.0.0, ::1) are not matched"

--- a/insecure_configuration/patterns.yml
+++ b/insecure_configuration/patterns.yml
@@ -19,8 +19,8 @@ patterns:
         \z|["'`\s,;]
     expected:
       - name: WebSecurityConfig.java
-        start_offset: 1364
-        end_offset: 1393
+        start_offset: 1344
+        end_offset: 1373
     test:
       data: ldap://ldap.corp.acme.com:389
       start_offset: 0
@@ -29,9 +29,9 @@ patterns:
   - name: Insecure trustServerCertificate
     type: insecure_trust_server_certificate
     description: |
-      trustServerCertificate=true disables TLS certificate validation on a JDBC
-      connection (CWE-295), so the driver accepts any server certificate and the
-      encrypted channel is unauthenticated (man-in-the-middle).
+      Setting the JDBC trustServerCertificate property to true disables TLS
+      certificate validation (CWE-295), so the driver accepts any server
+      certificate and the encrypted channel is unauthenticated (man-in-the-middle).
     comments:
       - "Matches only the insecure '=true' value; '=false' is not matched"
       - "Case-insensitive on the property name and value, allows spaces around '='"
@@ -46,17 +46,17 @@ patterns:
         \z|[^a-zA-Z]
     expected:
       - name: DbConnectivityCheck.java
-        start_offset: 693
-        end_offset: 720
+        start_offset: 671
+        end_offset: 698
       - name: DbConnectivityCheck.java
-        start_offset: 1258
-        end_offset: 1285
+        start_offset: 1228
+        end_offset: 1255
       - name: application-prod.yaml
-        start_offset: 190
-        end_offset: 217
+        start_offset: 185
+        end_offset: 212
       - name: application-prod.yaml
-        start_offset: 347
-        end_offset: 374
+        start_offset: 341
+        end_offset: 368
     test:
       data: trustServerCertificate=true
       start_offset: 0
@@ -86,11 +86,11 @@ patterns:
         - ^http://(?:localhost|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|0\.0\.0\.0|\[::1\]|::1)(?:[:/?#]|$)
     expected:
       - name: application-prod.yaml
-        start_offset: 2317
-        end_offset: 2363
+        start_offset: 2232
+        end_offset: 2278
       - name: application-prod.yaml
-        start_offset: 2605
-        end_offset: 2657
+        start_offset: 2511
+        end_offset: 2563
     test:
       data: "url: http://reports.corp.acme.com:8080/ReportServer"
       start_offset: 5

--- a/insecure_configuration/patterns.yml
+++ b/insecure_configuration/patterns.yml
@@ -39,7 +39,7 @@ patterns:
     regex:
       version: 0.1
       pattern: |
-        [tT]rust[sS]erver[cC]ertificate[ \t]*=[ \t]*[tT]rue
+        (?i)trustServerCertificate[ \t]*=[ \t]*true
       start: |
         \A|[^a-zA-Z]
       end: |


### PR DESCRIPTION
## What

Adds a new `insecure_configuration` folder with three secret-scanning custom patterns that surface insecure transport and TLS configuration. These cover items 3, 4, and 5 of the missed detections reported in the field interview (github/field-security-codeql#226), where secrets/insecure settings live in `.yaml`/`.properties`/Java config that pattern-based scanning previously missed.

| # | Pattern | CWE | Matches | Does not match |
|---|---------|-----|---------|----------------|
| 3 | Cleartext LDAP URL | CWE-319 | ``ldap://host`` | ``ldaps://`` |
| 4 | Insecure trustServerCertificate | CWE-295 | ``trustServerCertificate=true`` | ``=false`` |
| 5 | Cleartext HTTP endpoint | CWE-319 | ``http://`` behind a url/endpoint config key | ``https://``, loopback/localhost, bare schema URLs |

Each is intended to pair with a CodeQL query that confirms the value reaches the relevant sink (LDAP bind, JDBC connection, network request).

## False-positive handling

- **Cleartext LDAP**: only the insecure ``ldap://`` scheme matches. ``ldaps://`` never contains the literal ``ldap://`` so it is excluded by construction.
- **trustServerCertificate**: matches only the insecure ``=true`` value; ``=false`` is not matched. Case-insensitive on the property name and value, allows spaces around ``=``.
- **Cleartext HTTP**: ``http://`` is anchored on a preceding URL/endpoint-style config key (``url``, ``uri``, ``endpoint``, ``base-url``, ``href``, ``callback``, ``webhook``, ``target``, ``location``) to avoid the huge FP surface of unrelated ``http://`` URLs such as XML namespaces and Maven schema locations. Loopback and unspecified addresses (``localhost``, ``127.0.0.0/8``, ``0.0.0.0``, ``::1``) are excluded via an additional not-match. ``https://`` is never matched.

## Testing

Test fixtures are derived from a representative sample Spring/LDAP app:

- ``WebSecurityConfig.java`` (cleartext ``ldap://`` bind URL)
- ``application-prod.yaml`` (``trustServerCertificate=true`` plus two ``http://`` report/audit endpoints)
- ``DbConnectivityCheck.java`` (``trustServerCertificate=true`` in a JDBC URL and Javadoc)
- ``negatives.conf`` (negative controls: ``ldaps://``, ``https://``, ``trustServerCertificate=false``, ``http://localhost`` / ``127.0.0.1`` / ``0.0.0.0``, and bare ``http://`` schema URLs)

The ``expected`` start/end offsets in ``patterns.yml`` were computed against these fixtures and confirmed to match exactly, with zero matches against the negative controls. The hyperscan unit-test workflow validates these offsets.

> Note: ``__snapshots__`` are intentionally not included; they are generated separately against the Secret Scanning API, consistent with how patterns are added in this repo.

Refs: github/field-security-codeql#226
